### PR TITLE
:bug: fix: mypypath to run stubtests

### DIFF
--- a/.pre-commit-config.yaml.template
+++ b/.pre-commit-config.yaml.template
@@ -74,4 +74,4 @@ repos:
       language: system
       pass_filenames: false
       types: [pyi]
-      entry: stubtest PACKAGE_NAME
+      entry: stubtest --mypy-config-file mypy.ini PACKAGE_NAME

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ check: # Dependencies
 create: check
 	@poetry init --name=$(name) --python=">=3.10"
 	@poetry add -G dev "pre-commit>=2.20.0" "pytest>=7.2.0" "pyright^1.1.278" "flake8^5.0.4" "mypy^0.982"
+	@echo '\n[tool.pyright]\
+	\ninclude = ["$(name)", "tests"]\
+	\nreportMissingImports = true\
+	\nreportMissingTypeStubs = true' >> pyproject.toml
 	@mkdir $(name) && touch $(name)/__init__.py
 	@mkdir -p typings/$(name) && touch typings/$(name)/__init__.pyi
 	@mkdir tests && \

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+mypy_path=./typings


### PR DESCRIPTION
`stubtest` will not run properly w/o the mypy_path configured properly and pointing the `typings` folder.
So, to fix this, we can include a `mypy.ini` with that configuration and provide the `--mypy-config-file` to the `stubtest` command.

This way it will locate the stub files...